### PR TITLE
Added enabled parameter to EnvironmentVariableEntry

### DIFF
--- a/Sources/xctestplanner/Core/Entity/TestPlanModel.swift
+++ b/Sources/xctestplanner/Core/Entity/TestPlanModel.swift
@@ -45,6 +45,7 @@ struct CommandLineArgumentEntry: Codable {
 // MARK: - EnvironmentVariableEntry
 struct EnvironmentVariableEntry: Codable {
     var key, value: String
+    let enabled: Bool?
 }
 
 // MARK: - LocationScenario

--- a/Sources/xctestplanner/Core/Helper/TestPlanHelper.swift
+++ b/Sources/xctestplanner/Core/Helper/TestPlanHelper.swift
@@ -94,12 +94,12 @@ class TestPlanHelper {
         testPlan.defaultOptions.region = region.uppercased()
     }
     
-    static func setEnvironmentVariable(testPlan: inout TestPlanModel, key: String, value: String) {
+    static func setEnvironmentVariable(testPlan: inout TestPlanModel, key: String, value: String, enabled: Bool? = true) {
         Logger.log("Setting environment variable with key '\(key)' and value '\(value)' in test plan", level: .info)
         if testPlan.defaultOptions.environmentVariableEntries == nil {
             testPlan.defaultOptions.environmentVariableEntries = []
         }
-        testPlan.defaultOptions.environmentVariableEntries?.append(EnvironmentVariableEntry(key: key, value: value))
+        testPlan.defaultOptions.environmentVariableEntries?.append(EnvironmentVariableEntry(key: key, value: value, enabled: enabled))
     }
     
     static func setArgument(testPlan: inout TestPlanModel, key: String, disabled: Bool) {


### PR DESCRIPTION
This parameter is important because some environment options that are disabled can become enabled after using xctestplanner